### PR TITLE
Fix typo error in homepage : spaning to spanning

### DIFF
--- a/en/docs/index.md
+++ b/en/docs/index.md
@@ -525,7 +525,7 @@ template: templates/single-column.html
                                     </div>
                                 </div>
                                 <hr/>
-                                <p class="removeTopMargin">Manage APIs spaning multiple cloud platforms, on-premises systems, or regions</p>
+                                <p class="removeTopMargin">Manage APIs spanning multiple cloud platforms, on-premises systems, or regions</p>
                                 <div>
                                     <ul>
                                         <li><a href="{{base_path}}/deploy-and-publish/deploy-on-gateway/federated-gateways/deploy-on-aws-api-gateway/">AWS API Gateway</a></li>


### PR DESCRIPTION
Fixed a typo error in the homepage documentation where "spaning" was used instead of "spanning". This ensures clearer and more accurate content for users. This contribution is part of my application for the WSO2 engineering internship.

## Purpose
A typo ("spaning" instead of "spanning") was identified in the homepage documentation, which could confuse users. 

## Goals
Correct the typo to ensure accurate and professional documentation for all users.

## Approach
Manually edited the Markdown file to replace "spaning" with "spanning". 

## User stories
This is a minor documentation fix, 

## Release note
This is a minor typo fix not requiring a release note.

## Documentation
The change is the documentation itself; no additional documentation update is needed.

## Training
No impact on training content.

## Certification
This typo fix does not affect certification exams.

## Marketing
No marketing impact from this change.

## Automation tests
 - Unit tests 
   This is a documentation change, not code.
 - Integration tests
   No integration tests required for a typo fix.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
   Yes - No code changes; only documentation updated.
 - Ran FindSecurityBugs plugin and verified report? Yes/No
   No - No code changes to analyze.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? Yes/No
   Yes - No sensitive data included.

## Samples
No samples affected.

## Related PRs
This is a standalone fix.

## Migrations (if applicable)
No migration required.

## Test environment
Tested via GitHub preview; no runtime environment needed for document change.

## Learning
Reviewed the WSO2 API Manager documentation to identify the typo. No external resources were needed beyond the repo itself.